### PR TITLE
Add spells per day

### DIFF
--- a/boltcaster.md
+++ b/boltcaster.md
@@ -21,16 +21,16 @@ The boltcaster's class skills are Climb (Str), Intimidate (Cha), Perception (Wis
 
 Level | Base Attack Bonus | Fort Save | Ref Save | Will Save | Special | Spells per Day
 ------|-------------------|-----------|----------|-----------|---------|---------------
-1st | +0 | +0 | +0 | +1 | |
-2nd | +1 | +1 | +1 | +1 | |
-3rd | +2 | +1 | +1 | +2 | |
-4th | +3 | +1 | +1 | +2 | |
-5th | +3 | +2 | +2 | +3 | |
-6th | +4 | +2 | +2 | +3 | |
-7th | +5 | +2 | +2 | +4 | |
-8th | +6 | +3 | +3 | +4 | |
-9th | +6 | +3 | +3 | +5 | |
-10th| +7 | +3 | +3 | +5 | |
+1st   | +0                |        +0 |       +0 |        +1 |         |
+2nd   | +1                |        +1 |       +1 |        +1 |         | +1 level of existing arcane spellcasting class
+3rd   | +2                |        +1 |       +1 |        +2 |         | +1 level of existing arcane spellcasting class
+4th   | +3                |        +1 |       +1 |        +2 |         | +1 level of existing arcane spellcasting class
+5th   | +3                |        +2 |       +2 |        +3 |         | +1 level of existing arcane spellcasting class
+6th   | +4                |        +2 |       +2 |        +3 |         | +1 level of existing arcane spellcasting class
+7th   | +5                |        +2 |       +2 |        +4 |         | +1 level of existing arcane spellcasting class
+8th   | +6                |        +3 |       +3 |        +4 |         | +1 level of existing arcane spellcasting class
+9th   | +6                |        +3 |       +3 |        +5 |         | +1 level of existing arcane spellcasting class
+10th  | +7                |        +3 |       +3 |        +5 |         | +1 level of existing arcane spellcasting class
 
 Class Features
 ==============


### PR DESCRIPTION
Added spells per day.  I decided to go with a 9/10 progression even though we're going to add quite a few special abilities because this class is caster-oriented rather than combat-oriented.  That's reflected in the 3/4 BAB progression.  Arcane Archer gets 7/10 spells and a 1/1 BAB progression, whereas Eldritch Knight gets 9/10 and 1/1 respectively, so this doesn't seem out of line to me.

I think I'm leaving myself decent headroom to add special abilities, since all of BAB, skill, HD, and save progression are so far strictly worse than Arcane Archer.